### PR TITLE
force alpine version at 3.9 because edge breaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.9
 
 RUN apk add --no-cache --update shadow bash xpra py2-pip xterm && \
     pip install websockify lz4 && \


### PR DESCRIPTION
I also tried it with 3.10, but not with all subversions of 3.9 and 3.10